### PR TITLE
Allow CUSTOM_PHP_INI=true to be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,15 @@ Only TCP/8000 is exposed.
 Environment variables
 ---------------------
 
-All of the environment variables that are used were shown above.
+All of the environment variables that are supported:
 
     USE_SVN=true
     SVN_USER=username
     SVN_PASS=password
     SVN_REPO=http://url/to/repo@revision
+
+    # Will not mess with the php.ini if you supply your own via volume mount
+    CUSTOM_PHP_INI=true
 
 If you don't have a subscription but run your own managed copy, feel free to
 sub-in your own repo.

--- a/bin/my_init.d/set_php_tz.sh
+++ b/bin/my_init.d/set_php_tz.sh
@@ -3,20 +3,22 @@
 # == Title: set_php_tz.sh
 # Set the timezone in PHP files, default to UTC
 
-if [ -f /etc/container_environment/TZ ] ; then
-  sed -i \
-      "s#\;date\.timezone\ \=#date\.timezone\ \=\ $TZ#g" \
-      /etc/php5/cli/php.ini
-  sed -i \
-      "s#\;date\.timezone\ \=#date\.timezone\ \=\ $TZ#g" \
-      /etc/php5/apache2/php.ini
-else
-  echo "Timezone not specified by environment variable"
-  echo UTC > /etc/container_environment/TZ
-  sed -i \
-      "s#\;date\.timezone\ \=#date\.timezone\ \=\ UTC#g" \
-      /etc/php5/cli/php.ini
-  sed -i \
-      "s#\;date\.timezone\ \=#date\.timezone\ \=\ UTC#g" \
-      /etc/php5/apache2/php.ini
+if [[ $CUSTOM_PHP_INI != 'true' ]] ; then
+    if [ -f /etc/container_environment/TZ ] ; then
+      sed -i \
+          "s#\;date\.timezone\ \=#date\.timezone\ \=\ $TZ#g" \
+          /etc/php5/cli/php.ini
+      sed -i \
+          "s#\;date\.timezone\ \=#date\.timezone\ \=\ $TZ#g" \
+          /etc/php5/apache2/php.ini
+    else
+      echo "Timezone not specified by environment variable"
+      echo UTC > /etc/container_environment/TZ
+      sed -i \
+          "s#\;date\.timezone\ \=#date\.timezone\ \=\ UTC#g" \
+          /etc/php5/cli/php.ini
+      sed -i \
+          "s#\;date\.timezone\ \=#date\.timezone\ \=\ UTC#g" \
+          /etc/php5/apache2/php.ini
+    fi
 fi


### PR DESCRIPTION
This will not mess with /etc/php5/apache2/php.ini. Useful if you're using
a custom php.ini which is volume mounted.
