### PR TITLE
Improvement: RRDCacheD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,6 +87,7 @@ RUN apt-get update -q && \
       php-pear \
       pwgen \
       python-mysqldb \
+      rrdcached \
       rrdtool \
       snmp \
       software-properties-common \
@@ -121,6 +122,7 @@ RUN chmod +x /etc/my_init.d/* && \
 # Configure apache2 to serve Observium app
 COPY ["conf/apache2.conf", "conf/ports.conf", "/etc/apache2/"]
 COPY conf/apache-observium /etc/apache2/sites-available/000-default.conf
+COPY conf/rrdcached /etc/default/rrdcached
 RUN rm /etc/apache2/sites-available/default-ssl.conf && \
     echo www-data > /etc/container_environment/APACHE_RUN_USER && \
     echo www-data > /etc/container_environment/APACHE_RUN_GROUP && \

--- a/README.md
+++ b/README.md
@@ -97,3 +97,11 @@ As in the list above, setting `USE_WEATHERMAP` will install network-weathermap
 under the htmldir if not there already and schedule map-poller.php in cron.
 
 To modify configuration, volume mount observium's htmldir to access weathermap.
+
+Notes
+-----
+
+This image installs and runs rrdcached. To make use of it, make sure your
+observium configuration sets
+
+    $config['rrdcached']    = "unix:/var/run/rrdcached.sock"

--- a/bin/my_init.d/rrdcached.sh
+++ b/bin/my_init.d/rrdcached.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+#
+# Start up rrdcache
+
+/etc/init.d/rrdcached start

--- a/conf/rrdcached
+++ b/conf/rrdcached
@@ -1,0 +1,20 @@
+# /etc/default/rrdcached
+
+# 0: start rrdcached on boot, 1: do not start rrdcached on boot
+# default: 0
+DISABLE=0
+
+# options to be passed to rrdcached
+# (do not specify -p <pidfile> - this is handled by the init script)
+# default: see /etc/init.d/rrdcached
+OPTS="-w 1800 -z 1800 -f 3600 -s users -m 766 -l unix:/var/run/rrdcached.sock -j /var/lib/rrdcached/journal/ -F -b /opt/observium/rrd/ -B"
+
+# number of seconds to wait for rrdcached to shut down
+# (writing the data to disk may take some time;
+# tune this according to your setup)
+# default: 30
+MAXWAIT=30
+
+# 0: do not enable core-files, 1: enable core-files ... if rrdcached crashes
+# default: 0
+ENABLE_COREFILES=0


### PR DESCRIPTION
```
commit 5f35f55ab366fc40fae4f6fee75d3bb9547d3e54
Author: Codey Oxley <codey@yelp.com>
Date:   Mon Aug 10 15:37:20 2015 -0700

    Improvement: RRDCacheD

    Added RRDCacheD support. UNIX socket set for group
    users with 766 perms. See 'Notes' section of README.md
    for usage
```

Testing done locally, confirmed working graph drawing.
